### PR TITLE
Todo: fix StreamSinkProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Then, Kafka to Cassandra
 ## Output data 
 Stored inside Kafka and Cassandra for example only.
 Cassandra's Sinks uses the [ForeachWriter](https://spark.apache.org/docs/latest/api/scala/index.html#org.apache.spark.sql.ForeachWriter) and also the [StreamSinkProvider](https://spark.apache.org/docs/latest/api/scala/index.html#org.apache.spark.sql.sources.StreamSinkProvider) to compare both sinks.
-
+One is using the Datastax's Cassandra saveToCassandra method. The other another method, more messy, that uses CQL on a custom foreach loop.
 ### Kafka topic
 topic:test
 ### Cassandra Table
@@ -60,6 +60,10 @@ cqlsh> SELECT * FROM test.radio;
 * https://databricks.com/blog/2017/04/04/real-time-end-to-end-integration-with-apache-kafka-in-apache-sparks-structured-streaming.html
 * https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#using-foreach
 * https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#output-modes
+
+## Inspired by
+* https://github.com/ansrivas/spark-structured-streaming
+* From Holden Karau's High Performance Spark : https://github.com/holdenk/spark-structured-streaming-ml/blob/master/src/main/scala/com/high-performance-spark-examples/structuredstreaming/CustomSink.scala#L66
 
 ## Requirements
 * Cassandra 3.10

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -11,7 +11,7 @@ object Main {
   def main(args: Array[String]) {
     val spark = SparkHelper.getAndConfigureSparkSession()
 
-    //Batch
+    //Classic Batch
     ParquetService.batchWay()
 
     //Stream
@@ -26,11 +26,11 @@ object Main {
     //Debug Kafka input Stream
     KafkaSink.debugStream(kafkaInputDF)
 
+    CassandraDriver.getTestInfo()
     //Saving using the foreach method
     CassandraDriver.saveForeach(kafkaInputDF)
 
     //Saving using Datastax connector's saveToCassandra method
-    //@ TODO Fix me
     CassandraDriver.saveStreamSinkProvider(kafkaInputDF)
 
     //@TODO debug

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -30,7 +30,8 @@ object Main {
     CassandraDriver.saveForeach(kafkaInputDF)
 
     //Saving using Datastax connector's saveToCassandra method
-    //@ TODO Fix me CassandraDriver.saveStreamSinkProvider(kafkaInputDF)
+    //@ TODO Fix me
+    CassandraDriver.saveStreamSinkProvider(kafkaInputDF)
 
     //@TODO debug
     CassandraDriver.debug()

--- a/src/main/scala/cassandra/CassandraDriver.scala
+++ b/src/main/scala/cassandra/CassandraDriver.scala
@@ -49,6 +49,7 @@ object CassandraDriver {
       .writeStream
       .format("cassandra.sink.CassandraSinkProvider")
       .queryName("KafkaToCassandraStreamSinkProvider")
+      .format("update") //@TODO check how to handle this in a custom StreakSnkProvider
       .start()
   }
 

--- a/src/main/scala/cassandra/sink/CassandraSinkForeach.scala
+++ b/src/main/scala/cassandra/sink/CassandraSinkForeach.scala
@@ -5,7 +5,11 @@ import org.apache.spark.sql.ForeachWriter
 import radio.SimpleSongAggregation
 import spark.SparkHelper
 
-//https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#using-foreach
+/**
+  * Inspired by
+  * https://github.com/ansrivas/spark-structured-streaming/
+  * https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#using-foreach
+  */
 class CassandraSinkForeach() extends ForeachWriter[SimpleSongAggregation] {
   private val connector = CassandraConnector(SparkHelper.getSparkSession().sparkContext.getConf)
 
@@ -28,8 +32,9 @@ class CassandraSinkForeach() extends ForeachWriter[SimpleSongAggregation] {
   }
 
   //https://github.com/datastax/spark-cassandra-connector/blob/master/doc/reference.md#cassandra-connection-parameters
-  //connection.keep_alive_ms	5000	Period of time to keep unused connections open
+
   def close(errorOrNull: Throwable): Unit = {
     // close the connection
+    //connection.keep_alive_ms	--> 5000ms :	Period of time to keep unused connections open
   }
 }

--- a/src/main/scala/cassandra/sink/CassandraSinkProvider.scala
+++ b/src/main/scala/cassandra/sink/CassandraSinkProvider.scala
@@ -7,11 +7,12 @@ import org.apache.spark.sql.sources.StreamSinkProvider
 import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.{DataFrame, SQLContext}
 
-//From Holden Karau's https://github.com/holdenk/spark-structured-streaming-ml/blob/master/src/main/scala/com/high-performance-spark-examples/structuredstreaming/CustomSink.scala#L66
-abstract class CassandraSinkProvider extends StreamSinkProvider {
-  //@TODO Provided process must consume the dataset (e.g. call `foreach` or `collect`).
-  def process(df: DataFrame): Unit
-
+/**
+  From Holden Karau's High Performance Spark
+  https://github.com/holdenk/spark-structured-streaming-ml/blob/master/src/main/scala/com/high-performance-spark-examples/structuredstreaming/CustomSink.scala#L66
+  *
+  */
+class CassandraSinkProvider extends StreamSinkProvider {
   override def createSink(sqlContext: SQLContext,
                           parameters: Map[String, String],
                           partitionColumns: Seq[String],
@@ -20,15 +21,16 @@ abstract class CassandraSinkProvider extends StreamSinkProvider {
   }
 }
 
-
 /**
-  * idempotent and synchronous (@TODO check asynchronous/synchronous from Datastax's Spark connector) sink
+  * must be idempotent and synchronous (@TODO check asynchronous/synchronous from Datastax's Spark connector) sink
   */
 class CassandraSink() extends Sink {
   def saveToCassandra(df: DataFrame) = {
-    df.printSchema()
     df.show()
-    df.rdd.saveToCassandra(CassandraDriver.namespace, CassandraDriver.StreamProviderTableSink, SomeColumns("title", "artist", "radio", "count"))
+    df.rdd.saveToCassandra(CassandraDriver.namespace,
+      CassandraDriver.StreamProviderTableSink,
+      SomeColumns("title", "artist", "radio", "count")
+    )
   }
 
   /*

--- a/src/main/scala/cassandra/sink/CassandraSinkProvider.scala
+++ b/src/main/scala/cassandra/sink/CassandraSinkProvider.scala
@@ -1,7 +1,7 @@
 package cassandra.sink
 
 import cassandra.CassandraDriver
-import com.datastax.spark.connector.{SomeColumns, _}
+import com.datastax.spark.connector._
 import org.apache.spark.sql.execution.streaming.Sink
 import org.apache.spark.sql.sources.StreamSinkProvider
 import org.apache.spark.sql.streaming.OutputMode
@@ -9,7 +9,7 @@ import org.apache.spark.sql.{DataFrame, SQLContext}
 
 //From Holden Karau's https://github.com/holdenk/spark-structured-streaming-ml/blob/master/src/main/scala/com/high-performance-spark-examples/structuredstreaming/CustomSink.scala#L66
 abstract class CassandraSinkProvider extends StreamSinkProvider {
-  //@TODO Provided func must consume the dataset (e.g. call `foreach` or `collect`).
+  //@TODO Provided process must consume the dataset (e.g. call `foreach` or `collect`).
   def process(df: DataFrame): Unit
 
   override def createSink(sqlContext: SQLContext,
@@ -25,7 +25,7 @@ abstract class CassandraSinkProvider extends StreamSinkProvider {
   * idempotent and synchronous (@TODO check asynchronous/synchronous from Datastax's Spark connector) sink
   */
 class CassandraSink() extends Sink {
-  def process(df: DataFrame) = {
+  def saveToCassandra(df: DataFrame) = {
     df.printSchema()
     df.show()
     df.rdd.saveToCassandra(CassandraDriver.namespace, CassandraDriver.StreamProviderTableSink, SomeColumns("title", "artist", "radio", "count"))
@@ -37,6 +37,6 @@ class CassandraSink() extends Sink {
    */
   override def addBatch(batchId: Long, df: DataFrame) = {
     println(s"saveToCassandra batchId : ${batchId}")
-    process(df)
+    saveToCassandra(df)
   }
 }


### PR DESCRIPTION
Error using the [StreamProvider](https://github.com/polomarcus/Spark-Structured-Streaming-Examples/blob/fixStreamProvider/src/main/scala/cassandra/sink/CassandraSinkProvider.scala) based on @holdenk 's [Custom Sink example](https://github.com/holdenk/spark-structured-streaming-ml/blob/master/src/main/scala/com/high-performance-spark-examples/structuredstreaming/CustomSink.scala)

```
[error] (run-main-0) java.lang.InstantiationException
java.lang.InstantiationException
	at sun.reflect.InstantiationExceptionConstructorAccessorImpl.newInstance(InstantiationExceptionConstructorAccessorImpl.java:48)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at java.lang.Class.newInstance(Class.java:442)
	at org.apache.spark.sql.execution.datasources.DataSource.createSink(DataSource.scala:272)
	at org.apache.spark.sql.streaming.DataStreamWriter.start(DataStreamWriter.scala:272)
	at cassandra.CassandraDriver$.saveStreamSinkProvider(CassandraDriver.scala:52)
	at main.Main$.main(Main.scala:34)
	at main.Main.main(Main.scala)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
```
