### PR TITLE
Saving Kafka Metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ One is using the Datastax's Cassandra saveToCassandra method. The other another 
 From Spark's doc about batch duration:
 > Trigger interval: Optionally, specify the trigger interval. If it is not specified, the system will check for availability of new data as soon as the previous processing has completed. If a trigger time is missed because the previous processing has not completed, then the system will attempt to trigger at the next trigger point, not immediately after the processing has completed.
 
-    ### Kafka topic
-topic:test
+### Kafka topic
+One topic "test" with only one partition
+
 ### Cassandra Table
 A table for the ForeachWriter
 ```
@@ -52,6 +53,7 @@ CREATE TABLE test.kafkaMetadata (
 );
 ```
 
+
 #### Table Content
 ##### Radio
 ```
@@ -72,11 +74,20 @@ cqlsh> SELECT * FROM test.radio;
 ```
 
 ##### Kafka Metadata
+When doing an application upgrade, we cannot use [checkpointing](https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#recovering-from-failures-with-checkpointing), so we need to store our offset into a external datasource, here Cassandra is chosen.
+Then, when starting our kafka source we need to use the option "StartingOffsets" with a json string like 
+```
+""" {"topicA":{"0":23,"1":-1},"topicB":{"0":-2}} """
+```
+Learn more [in the official Spark's doc](https://spark.apache.org/docs/latest/structured-streaming-kafka-integration.html#creating-a-kafka-source-for-batch-queries).
+
+In the case, there is not Kafka's metadata stored inside Cassandra, **earliest** is used.
+
 ```
 cqlsh> SELECT * FROM test.kafkametadata;
-
  partition | offset
 -----------+--------
+         0 |    171
 ```
 
 ## Useful links

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Then, Kafka to Cassandra
 ## Output data 
 Stored inside Kafka and Cassandra for example only.
 Cassandra's Sinks uses the [ForeachWriter](https://spark.apache.org/docs/latest/api/scala/index.html#org.apache.spark.sql.ForeachWriter) and also the [StreamSinkProvider](https://spark.apache.org/docs/latest/api/scala/index.html#org.apache.spark.sql.sources.StreamSinkProvider) to compare both sinks.
-One is using the Datastax's Cassandra saveToCassandra method. The other another method, more messy, that uses CQL on a custom foreach loop.
+One is using the Datastax's Cassandra saveToCassandra method. The other another method, messier (untyped), that uses CQL on a custom foreach loop.
 
 
 From Spark's doc about batch duration:

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ cqlsh> SELECT * FROM test.kafkametadata;
 ```
 
 ## Useful links
+* [Processing Data in Apache Kafka with Structured Streaming in Apache Spark 2.2](https://databricks.com/blog/2017/04/26/processing-data-in-apache-kafka-with-structured-streaming-in-apache-spark-2-2.html)
 * https://databricks.com/blog/2017/04/04/real-time-end-to-end-integration-with-apache-kafka-in-apache-sparks-structured-streaming.html
 * https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#using-foreach
 * https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#output-modes

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Then, Kafka to Cassandra
 ## Output data 
 Stored inside Kafka and Cassandra for example only.
 Cassandra's Sinks uses the [ForeachWriter](https://spark.apache.org/docs/latest/api/scala/index.html#org.apache.spark.sql.ForeachWriter) and also the [StreamSinkProvider](https://spark.apache.org/docs/latest/api/scala/index.html#org.apache.spark.sql.sources.StreamSinkProvider) to compare both sinks.
-
+One is using the Datastax's Cassandra saveToCassandra method. The other another method, more messy, that uses CQL on a custom foreach loop.
 ### Kafka topic
 topic:test
 ### Cassandra Table
@@ -60,6 +60,10 @@ cqlsh> SELECT * FROM test.radio;
 * https://databricks.com/blog/2017/04/04/real-time-end-to-end-integration-with-apache-kafka-in-apache-sparks-structured-streaming.html
 * https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#using-foreach
 * https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#output-modes
+
+## Inspired by
+* https://github.com/ansrivas/spark-structured-streaming
+* From Holden Karau's High Performance Spark : https://github.com/holdenk/spark-structured-streaming-ml/blob/master/src/main/scala/com/high-performance-spark-examples/structuredstreaming/CustomSink.scala#L66
 
 ## Requirements
 * Cassandra 3.10

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Then, Kafka to Cassandra
 Stored inside Kafka and Cassandra for example only.
 Cassandra's Sinks uses the [ForeachWriter](https://spark.apache.org/docs/latest/api/scala/index.html#org.apache.spark.sql.ForeachWriter) and also the [StreamSinkProvider](https://spark.apache.org/docs/latest/api/scala/index.html#org.apache.spark.sql.sources.StreamSinkProvider) to compare both sinks.
 One is using the Datastax's Cassandra saveToCassandra method. The other another method, more messy, that uses CQL on a custom foreach loop.
+
+
+From Spark's doc about batch duration:
+> Trigger interval: Optionally, specify the trigger interval. If it is not specified, the system will check for availability of new data as soon as the previous processing has completed. If a trigger time is missed because the previous processing has not completed, then the system will attempt to trigger at the next trigger point, not immediately after the processing has completed.
 ### Kafka topic
 topic:test
 ### Cassandra Table
@@ -38,7 +42,17 @@ CREATE TABLE test.radioOtherSink (
 );
 ```
 
+A 3rd sink to store **kafka metadata** in case checkpointing is not available (application upgrade for example)
+```
+CREATE TABLE test.kafkaMetadata (
+  partition int,
+  offset bigint,
+  PRIMARY KEY (partition)
+);
+```
 
+#### Table Content
+##### Radio
 ```
 cqlsh> SELECT * FROM test.radio;
 
@@ -56,6 +70,14 @@ cqlsh> SELECT * FROM test.radio;
 
 ```
 
+##### Kafka Metadata
+```
+cqlsh> SELECT * FROM test.kafkametadata;
+
+ partition | offset
+-----------+--------
+```
+
 ## Useful links
 * https://databricks.com/blog/2017/04/04/real-time-end-to-end-integration-with-apache-kafka-in-apache-sparks-structured-streaming.html
 * https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#using-foreach
@@ -64,8 +86,10 @@ cqlsh> SELECT * FROM test.radio;
 ## Inspired by
 * https://github.com/ansrivas/spark-structured-streaming
 * From Holden Karau's High Performance Spark : https://github.com/holdenk/spark-structured-streaming-ml/blob/master/src/main/scala/com/high-performance-spark-examples/structuredstreaming/CustomSink.scala#L66
+* Jay Kreps blog articles
 
 ## Requirements
+@TODO docker compose
 * Cassandra 3.10
 * Kafka 0.10+ (with Zookeeper)
 

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,12 +1,11 @@
 package main
 
 import cassandra.CassandraDriver
-import kafka.{KafkaService, KafkaSink, KafkaSource}
+import kafka.{KafkaSink, KafkaSource}
 import parquetHelper.ParquetService
 import spark.SparkHelper
 
 object Main {
-
 
   def main(args: Array[String]) {
     val spark = SparkHelper.getAndConfigureSparkSession()
@@ -21,14 +20,16 @@ object Main {
     val queryToKafka = KafkaSink.writeStream(staticInputDF)
 
     //Read from Kafka
-    val kafkaInputDF = KafkaSource.read()
+    //@TODO read from Cassandra last offsets saved
+    //val startingOffsets = CassandraDriver.getKafaMetadata()
+    val kafkaInputDF = KafkaSource.read(startingOffsets = "earliest")
 
     //Debug Kafka input Stream
     KafkaSink.debugStream(kafkaInputDF)
 
     CassandraDriver.getTestInfo()
     //Saving using the foreach method
-    CassandraDriver.saveForeach(kafkaInputDF)
+    //CassandraDriver.saveForeach(kafkaInputDF)
 
     //Saving using Datastax connector's saveToCassandra method
     CassandraDriver.saveStreamSinkProvider(kafkaInputDF)

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -11,7 +11,7 @@ object Main {
     val spark = SparkHelper.getAndConfigureSparkSession()
 
     //Classic Batch
-    ParquetService.batchWay()
+    //ParquetService.batchWay()
 
     //Stream
     val staticInputDF = ParquetService.streamingWay()
@@ -28,8 +28,9 @@ object Main {
     KafkaSink.debugStream(kafkaInputDF)
 
     CassandraDriver.getTestInfo()
+
     //Saving using the foreach method
-    //CassandraDriver.saveForeach(kafkaInputDF) //Untype/unsafe method using CQL
+    //CassandraDriver.saveForeach(kafkaInputDF) //Untype/unsafe method using CQL  --> just here for example
 
     //Saving using Datastax connector's saveToCassandra method
     CassandraDriver.saveStreamSinkProvider(kafkaInputDF)

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -20,7 +20,7 @@ object Main {
     val queryToKafka = KafkaSink.writeStream(staticInputDF)
 
     //Read from Kafka
-    //@TODO read from Cassandra last offsets saved
+    //@TODO read from Cassandra last offsets saved, /!\ synchrously
     //val startingOffsets = CassandraDriver.getKafaMetadata()
     val kafkaInputDF = KafkaSource.read(startingOffsets = "earliest")
 
@@ -29,7 +29,7 @@ object Main {
 
     CassandraDriver.getTestInfo()
     //Saving using the foreach method
-    //CassandraDriver.saveForeach(kafkaInputDF)
+    //CassandraDriver.saveForeach(kafkaInputDF) //Untype/unsafe method using CQL
 
     //Saving using Datastax connector's saveToCassandra method
     CassandraDriver.saveStreamSinkProvider(kafkaInputDF)

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -11,7 +11,7 @@ object Main {
   def main(args: Array[String]) {
     val spark = SparkHelper.getAndConfigureSparkSession()
 
-    //Batch
+    //Classic Batch
     ParquetService.batchWay()
 
     //Stream
@@ -26,11 +26,11 @@ object Main {
     //Debug Kafka input Stream
     KafkaSink.debugStream(kafkaInputDF)
 
+    CassandraDriver.getTestInfo()
     //Saving using the foreach method
     CassandraDriver.saveForeach(kafkaInputDF)
 
     //Saving using Datastax connector's saveToCassandra method
-    //@ TODO Fix me
     CassandraDriver.saveStreamSinkProvider(kafkaInputDF)
 
     //@TODO debug

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -9,9 +9,8 @@ object Main {
 
   def main(args: Array[String]) {
     val spark = SparkHelper.getAndConfigureSparkSession()
-
     //Classic Batch
-    ParquetService.batchWay()
+    //ParquetService.batchWay()
 
     //Stream
     val staticInputDF = ParquetService.streamingWay()
@@ -20,22 +19,18 @@ object Main {
     val queryToKafka = KafkaSink.writeStream(staticInputDF)
 
     //Read from Kafka
-    //@TODO read from Cassandra last offsets saved, /!\ synchrously
-    //val startingOffsets = CassandraDriver.getKafaMetadata()
-    val kafkaInputDF = KafkaSource.read(startingOffsets = "earliest")
+    //@TODO /!\ synchronously
+    val (startingOption, partitionsAndOffsets) = CassandraDriver.getKafaMetadata()
+    val kafkaInputDF = KafkaSource.read(startingOption, partitionsAndOffsets)
 
     //Debug Kafka input Stream
     KafkaSink.debugStream(kafkaInputDF)
 
-    CassandraDriver.getTestInfo()
     //Saving using the foreach method
     //CassandraDriver.saveForeach(kafkaInputDF) //Untype/unsafe method using CQL
 
     //Saving using Datastax connector's saveToCassandra method
     CassandraDriver.saveStreamSinkProvider(kafkaInputDF)
-
-    //@TODO debug
-    CassandraDriver.debug()
 
     spark.streams.awaitAnyTermination()
   }

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -30,7 +30,8 @@ object Main {
     CassandraDriver.saveForeach(kafkaInputDF)
 
     //Saving using Datastax connector's saveToCassandra method
-    //@ TODO Fix me CassandraDriver.saveStreamSinkProvider(kafkaInputDF)
+    //@ TODO Fix me
+    CassandraDriver.saveStreamSinkProvider(kafkaInputDF)
 
     //@TODO debug
     CassandraDriver.debug()

--- a/src/main/scala/cassandra/CassandraDriver.scala
+++ b/src/main/scala/cassandra/CassandraDriver.scala
@@ -49,6 +49,7 @@ object CassandraDriver {
       .writeStream
       .format("cassandra.sink.CassandraSinkProvider")
       .queryName("KafkaToCassandraStreamSinkProvider")
+      .format("update") //@TODO check how to handle this in a custom StreakSnkProvider
       .start()
   }
 

--- a/src/main/scala/cassandra/CassandraDriver.scala
+++ b/src/main/scala/cassandra/CassandraDriver.scala
@@ -57,12 +57,12 @@ object CassandraDriver {
     df
       .writeStream
       .format("cassandra.sink.CassandraSinkProvider")
+      .outputMode("update")
       .queryName("KafkaToCassandraStreamSinkProvider")
       .start()
   }
 
   /**
-    * @TODO how to retrieve data from cassandra synchronously
     * @TODO handle more topic name, for our example we only use the topic "test"
     *
     *  we can use collect here as kafkameta data is not big at all

--- a/src/main/scala/cassandra/CassandraKafkaMetadata.scala
+++ b/src/main/scala/cassandra/CassandraKafkaMetadata.scala
@@ -1,0 +1,17 @@
+package cassandra
+
+import kafka.KafkaMetadata
+
+object CassandraKafkaMetadata {
+  private def cql(metadata: KafkaMetadata): String = s"""
+       INSERT INTO test.kafkametadata (partition, offset)
+       VALUES(${metadata.partition}, ${metadata.offset})
+    """
+
+  //https://github.com/datastax/spark-cassandra-connector/blob/master/doc/1_connecting.md#connection-pooling
+  def save(metadata: KafkaMetadata) = {
+    CassandraDriver.connector.withSessionDo(session =>
+      session.execute(cql(metadata))
+    )
+  }
+}

--- a/src/main/scala/cassandra/sink/CassandraSink.scala
+++ b/src/main/scala/cassandra/sink/CassandraSink.scala
@@ -56,7 +56,7 @@ class CassandraSink() extends Sink {
       CassandraDriver.kafkaMetadata,
       SomeColumns("partition", "offset")
     )
-    
+
     //Otherway to save offset inside Cassandra
     //kafkaMetadata.collect().foreach(CassandraKafkaMetadata.save)
   }

--- a/src/main/scala/cassandra/sink/CassandraSink.scala
+++ b/src/main/scala/cassandra/sink/CassandraSink.scala
@@ -1,0 +1,63 @@
+package cassandra.sink
+
+import cassandra.{CassandraDriver, CassandraKafkaMetadata}
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.execution.streaming.Sink
+import org.apache.spark.sql.functions.max
+import spark.SparkHelper
+import cassandra.CassandraDriver
+import com.datastax.spark.connector._
+import kafka.KafkaMetadata
+import org.apache.spark.sql.execution.streaming.Sink
+import org.apache.spark.sql.types.LongType
+
+/**
+* must be idempotent and synchronous (@TODO check asynchronous/synchronous from Datastax's Spark connector) sink
+*/
+class CassandraSink() extends Sink {
+  private val spark = SparkHelper.getSparkSession()
+  import spark.implicits._
+  import org.apache.spark.sql.functions._
+
+  private def saveToCassandra(df: DataFrame) = {
+    println("Saving this DF to Cassandra")
+    val ds = CassandraDriver.getDatasetForCassandra(df)
+    ds.show() //Debug only
+
+    ds.rdd.saveToCassandra(CassandraDriver.namespace,
+      CassandraDriver.StreamProviderTableSink,
+      SomeColumns("title", "artist", "radio", "count")
+    )
+
+    saveKafkaMetaData(df)
+  }
+
+  /*
+   * As per SPARK-16020 arbitrary transformations are not supported, but
+   * converting to an RDD allows us to do magic.
+   */
+  override def addBatch(batchId: Long, df: DataFrame) = {
+    println(s"saveToCassandra batchId : ${batchId}")
+    saveToCassandra(df)
+  }
+
+  /**
+    * saving the highest value of offset per partition when checkpointing is not available (application upgrade for example)
+    * http://docs.datastax.com/en/cassandra/3.0/cassandra/dml/dmlTransactionsDiffer.html
+    * should be done in the same transaction as the data linked to the offsets
+    */
+  private def saveKafkaMetaData(df: DataFrame) = {
+    val kafkaMetadata = df.groupBy($"partition").agg(max($"offset").cast(LongType).as("offset")).as[KafkaMetadata]
+
+    println("saveKafkaMetaData")
+    kafkaMetadata.show()
+
+    kafkaMetadata.collect().foreach(CassandraKafkaMetadata.save)
+
+    /*kafkaMetadata.rdd.saveToCassandra(CassandraDriver.namespace,
+      CassandraDriver.kafkaMetadata
+      SomeColumns("partition", "offset")
+    )*/
+  }
+}
+

--- a/src/main/scala/cassandra/sink/CassandraSink.scala
+++ b/src/main/scala/cassandra/sink/CassandraSink.scala
@@ -52,12 +52,13 @@ class CassandraSink() extends Sink {
     println("saveKafkaMetaData")
     kafkaMetadata.show()
 
-    kafkaMetadata.collect().foreach(CassandraKafkaMetadata.save)
-
-    /*kafkaMetadata.rdd.saveToCassandra(CassandraDriver.namespace,
-      CassandraDriver.kafkaMetadata
+    kafkaMetadata.rdd.saveToCassandra(CassandraDriver.namespace,
+      CassandraDriver.kafkaMetadata,
       SomeColumns("partition", "offset")
-    )*/
+    )
+    
+    //Otherway to save offset inside Cassandra
+    //kafkaMetadata.collect().foreach(CassandraKafkaMetadata.save)
   }
 }
 

--- a/src/main/scala/cassandra/sink/CassandraSinkForeach.scala
+++ b/src/main/scala/cassandra/sink/CassandraSinkForeach.scala
@@ -1,5 +1,6 @@
 package cassandra.sink
 
+import cassandra.CassandraDriver
 import com.datastax.spark.connector.cql.CassandraConnector
 import org.apache.spark.sql.ForeachWriter
 import radio.SimpleSongAggregation
@@ -11,9 +12,7 @@ import spark.SparkHelper
   * https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#using-foreach
   */
 class CassandraSinkForeach() extends ForeachWriter[SimpleSongAggregation] {
-  private val connector = CassandraConnector(SparkHelper.getSparkSession().sparkContext.getConf)
-
-  private def cql(record: SimpleSongAggregation): String = s"""
+  private def cqlRadio(record: SimpleSongAggregation): String = s"""
        insert into test.radio (title, artist, radio, count)
        values('${record.title}', '${record.artist}', '${record.radio}', ${record.count})"""
 
@@ -26,8 +25,8 @@ class CassandraSinkForeach() extends ForeachWriter[SimpleSongAggregation] {
   //https://github.com/datastax/spark-cassandra-connector/blob/master/doc/1_connecting.md#connection-pooling
   def process(record: SimpleSongAggregation) = {
     println(s"Saving record: $record")
-    connector.withSessionDo(session =>
-      session.execute(cql(record))
+    CassandraDriver.connector.withSessionDo(session =>
+      session.execute(cqlRadio(record))
     )
   }
 

--- a/src/main/scala/cassandra/sink/CassandraSinkForeach.scala
+++ b/src/main/scala/cassandra/sink/CassandraSinkForeach.scala
@@ -5,7 +5,11 @@ import org.apache.spark.sql.ForeachWriter
 import radio.SimpleSongAggregation
 import spark.SparkHelper
 
-//https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#using-foreach
+/**
+  * Inspired by
+  * https://github.com/ansrivas/spark-structured-streaming/
+  * https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#using-foreach
+  */
 class CassandraSinkForeach() extends ForeachWriter[SimpleSongAggregation] {
   private val connector = CassandraConnector(SparkHelper.getSparkSession().sparkContext.getConf)
 
@@ -28,8 +32,9 @@ class CassandraSinkForeach() extends ForeachWriter[SimpleSongAggregation] {
   }
 
   //https://github.com/datastax/spark-cassandra-connector/blob/master/doc/reference.md#cassandra-connection-parameters
-  //connection.keep_alive_ms	5000	Period of time to keep unused connections open
+
   def close(errorOrNull: Throwable): Unit = {
     // close the connection
+    //connection.keep_alive_ms	--> 5000ms :	Period of time to keep unused connections open
   }
 }

--- a/src/main/scala/cassandra/sink/CassandraSinkProvider.scala
+++ b/src/main/scala/cassandra/sink/CassandraSinkProvider.scala
@@ -7,11 +7,12 @@ import org.apache.spark.sql.sources.StreamSinkProvider
 import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.{DataFrame, SQLContext}
 
-//From Holden Karau's https://github.com/holdenk/spark-structured-streaming-ml/blob/master/src/main/scala/com/high-performance-spark-examples/structuredstreaming/CustomSink.scala#L66
-abstract class CassandraSinkProvider extends StreamSinkProvider {
-  //@TODO Provided process must consume the dataset (e.g. call `foreach` or `collect`).
-  def process(df: DataFrame): Unit
-
+/**
+  From Holden Karau's High Performance Spark
+  https://github.com/holdenk/spark-structured-streaming-ml/blob/master/src/main/scala/com/high-performance-spark-examples/structuredstreaming/CustomSink.scala#L66
+  *
+  */
+class CassandraSinkProvider extends StreamSinkProvider {
   override def createSink(sqlContext: SQLContext,
                           parameters: Map[String, String],
                           partitionColumns: Seq[String],
@@ -20,15 +21,16 @@ abstract class CassandraSinkProvider extends StreamSinkProvider {
   }
 }
 
-
 /**
-  * idempotent and synchronous (@TODO check asynchronous/synchronous from Datastax's Spark connector) sink
+  * must be idempotent and synchronous (@TODO check asynchronous/synchronous from Datastax's Spark connector) sink
   */
 class CassandraSink() extends Sink {
   def saveToCassandra(df: DataFrame) = {
-    df.printSchema()
     df.show()
-    df.rdd.saveToCassandra(CassandraDriver.namespace, CassandraDriver.StreamProviderTableSink, SomeColumns("title", "artist", "radio", "count"))
+    df.rdd.saveToCassandra(CassandraDriver.namespace,
+      CassandraDriver.StreamProviderTableSink,
+      SomeColumns("title", "artist", "radio", "count")
+    )
   }
 
   /*

--- a/src/main/scala/cassandra/sink/CassandraSinkProvider.scala
+++ b/src/main/scala/cassandra/sink/CassandraSinkProvider.scala
@@ -38,7 +38,7 @@ class CassandraSink() extends Sink {
       SomeColumns("title", "artist", "radio", "count")
     )
 
-    saveKafkaMetaData(df) //@TODO should be in the same transanction than the previous operation
+    saveKafkaMetaData(df) //@TODO should be in the same transaction than the previous operation
   }
 
   /*

--- a/src/main/scala/cassandra/sink/CassandraSinkProvider.scala
+++ b/src/main/scala/cassandra/sink/CassandraSinkProvider.scala
@@ -1,12 +1,8 @@
 package cassandra.sink
 
-import cassandra.CassandraDriver
-import com.datastax.spark.connector._
-import org.apache.spark.sql.execution.streaming.Sink
 import org.apache.spark.sql.sources.StreamSinkProvider
 import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.{DataFrame, SQLContext}
-import spark.SparkHelper
 
 /**
   From Holden Karau's High Performance Spark
@@ -19,50 +15,5 @@ class CassandraSinkProvider extends StreamSinkProvider {
                           partitionColumns: Seq[String],
                           outputMode: OutputMode): CassandraSink = {
     new CassandraSink()
-  }
-}
-
-/**
-  * must be idempotent and synchronous (@TODO check asynchronous/synchronous from Datastax's Spark connector) sink
-  */
-class CassandraSink() extends Sink {
-  private val spark = SparkHelper.getSparkSession()
-  import spark.implicits._
-  import org.apache.spark.sql.functions._
-
-  private def saveToCassandra(df: DataFrame) = {
-    println("Saving this DF to Cassandra")
-    df.show() //Debug only
-
-    df.select($"title",$"artist",$"radio",$"count").rdd.saveToCassandra(CassandraDriver.namespace,
-      CassandraDriver.StreamProviderTableSink,
-      SomeColumns("title", "artist", "radio", "count")
-    )
-
-    saveKafkaMetaData(df) //@TODO should be in the same transaction than the previous operation
-  }
-
-  /*
-   * As per SPARK-16020 arbitrary transformations are not supported, but
-   * converting to an RDD allows us to do magic.
-   */
-  override def addBatch(batchId: Long, df: DataFrame) = {
-    println(s"saveToCassandra batchId : ${batchId}")
-    saveToCassandra(df)
-  }
-
-  /**
-    * saving the highest value of offset per partition when checkpointing is not available (application upgrade for example)
-    * @TODO should be done in the same transaction as the data linked to the offsets
-    */
-  private def saveKafkaMetaData(df: DataFrame) = {
-    val kafkaMetadata = df.groupBy($"partition").agg(max("$offset"))
-
-    kafkaMetadata.show()
-
-    kafkaMetadata.rdd.saveToCassandra(CassandraDriver.namespace,
-      CassandraDriver.kafkaMetadata,
-      SomeColumns("partition", "offset")
-    )
   }
 }

--- a/src/main/scala/cassandra/sink/CassandraSinkProvider.scala
+++ b/src/main/scala/cassandra/sink/CassandraSinkProvider.scala
@@ -1,7 +1,7 @@
 package cassandra.sink
 
 import cassandra.CassandraDriver
-import com.datastax.spark.connector.{SomeColumns, _}
+import com.datastax.spark.connector._
 import org.apache.spark.sql.execution.streaming.Sink
 import org.apache.spark.sql.sources.StreamSinkProvider
 import org.apache.spark.sql.streaming.OutputMode
@@ -9,7 +9,7 @@ import org.apache.spark.sql.{DataFrame, SQLContext}
 
 //From Holden Karau's https://github.com/holdenk/spark-structured-streaming-ml/blob/master/src/main/scala/com/high-performance-spark-examples/structuredstreaming/CustomSink.scala#L66
 abstract class CassandraSinkProvider extends StreamSinkProvider {
-  //@TODO Provided func must consume the dataset (e.g. call `foreach` or `collect`).
+  //@TODO Provided process must consume the dataset (e.g. call `foreach` or `collect`).
   def process(df: DataFrame): Unit
 
   override def createSink(sqlContext: SQLContext,
@@ -25,7 +25,7 @@ abstract class CassandraSinkProvider extends StreamSinkProvider {
   * idempotent and synchronous (@TODO check asynchronous/synchronous from Datastax's Spark connector) sink
   */
 class CassandraSink() extends Sink {
-  def process(df: DataFrame) = {
+  def saveToCassandra(df: DataFrame) = {
     df.printSchema()
     df.show()
     df.rdd.saveToCassandra(CassandraDriver.namespace, CassandraDriver.StreamProviderTableSink, SomeColumns("title", "artist", "radio", "count"))
@@ -37,6 +37,6 @@ class CassandraSink() extends Sink {
    */
   override def addBatch(batchId: Long, df: DataFrame) = {
     println(s"saveToCassandra batchId : ${batchId}")
-    process(df)
+    saveToCassandra(df)
   }
 }

--- a/src/main/scala/cassandra/sink/CassandraSinkProvider.scala
+++ b/src/main/scala/cassandra/sink/CassandraSinkProvider.scala
@@ -31,9 +31,10 @@ class CassandraSink() extends Sink {
   import org.apache.spark.sql.functions._
 
   private def saveToCassandra(df: DataFrame) = {
+    println("Saving this DF to Cassandra")
     df.show() //Debug only
 
-    df.rdd.saveToCassandra(CassandraDriver.namespace,
+    df.select($"title",$"artist",$"radio",$"count").rdd.saveToCassandra(CassandraDriver.namespace,
       CassandraDriver.StreamProviderTableSink,
       SomeColumns("title", "artist", "radio", "count")
     )
@@ -57,8 +58,10 @@ class CassandraSink() extends Sink {
   private def saveKafkaMetaData(df: DataFrame) = {
     val kafkaMetadata = df.groupBy($"partition").agg(max("$offset"))
 
+    kafkaMetadata.show()
+
     kafkaMetadata.rdd.saveToCassandra(CassandraDriver.namespace,
-      CassandraDriver.KafkaMetadata,
+      CassandraDriver.kafkaMetadata,
       SomeColumns("partition", "offset")
     )
   }

--- a/src/main/scala/kafka/KafkaMetadata.scala
+++ b/src/main/scala/kafka/KafkaMetadata.scala
@@ -1,0 +1,3 @@
+package kafka
+
+case class KafkaMetadata(partition: Long, offset: Long)

--- a/src/main/scala/kafka/KafkaService.scala
+++ b/src/main/scala/kafka/KafkaService.scala
@@ -14,6 +14,8 @@ object KafkaService {
 
   val radioStructureName = "radioCount"
 
+  val topicName = "test"
+
   val bootstrapServers = "localhost:9092"
 
   val schemaOutput = new StructType()

--- a/src/main/scala/kafka/KafkaSink.scala
+++ b/src/main/scala/kafka/KafkaSink.scala
@@ -23,8 +23,8 @@ object KafkaSink {
   }
 
   /**
-  Console sink from Kafka's stream
-    * @TODO should display Kafka's metadata (offset etc.)
+      Console sink from Kafka's stream
+    *
     */
   def debugStream(staticKafkaInputDF: DataFrame) = {
     staticKafkaInputDF

--- a/src/main/scala/kafka/KafkaSink.scala
+++ b/src/main/scala/kafka/KafkaSink.scala
@@ -22,17 +22,24 @@ object KafkaSink {
       .start()
   }
 
-  //Console sink from Kafka's stream
+  /**
+  Console sink from Kafka's stream
+    * @TODO should display Kafka's metadata (offset etc.)
+    */
   def debugStream(staticKafkaInputDF: DataFrame) = {
-    staticKafkaInputDF.select($"value".cast(StringType)).alias("value") //to avoid using cast to string multiple times
-      .select( get_json_object($"value", "$.radio").alias("radio"),
-      get_json_object($"value", "$.title").alias("title"),
-      get_json_object($"value", "$.artist").alias("artist"),
-      get_json_object($"value", "$.count").alias("count")
-    )
+    staticKafkaInputDF
+      .select($"topic", $"partition", $"offset", $"value".cast(StringType).alias("value")) //to avoid using cast to string multiple times
+      .select(
+        get_json_object($"value", "$.radio").alias("radio"),
+        get_json_object($"value", "$.title").alias("title"),
+        get_json_object($"value", "$.artist").alias("artist"),
+        get_json_object($"value", "$.count").alias("count"),
+        $"topic",
+        $"partition",
+        $"offset"
+      )
       .writeStream
-      .option("startingOffsets", "earliest")
-      .outputMode("update")
+      .queryName("Debug Stream Kafka")
       .format("console")
       .start()
   }

--- a/src/main/scala/kafka/KafkaSource.scala
+++ b/src/main/scala/kafka/KafkaSource.scala
@@ -33,14 +33,14 @@ object KafkaSource {
     *
     * startingOffsets should use a JSON coming from the lastest offsets saved in our DB (Cassandra here)
     */
-  def read(startingOffsets: String = "earliest") = {
+  def read(startingOption: String = "startingOffsets", partitionsAndOffsets: String = "earliest") = {
     spark
       .readStream
       .format("kafka")
       .option("kafka.bootstrap.servers", "localhost:9092")
-      .option("subscribe", "test")
-      .option("startingOffsets", startingOffsets) //this only applies when a new query is started and that resuming will always pick up from where the query left off
-      .load() //--> Partition, offsets, value, key etc.
+      .option("subscribe", KafkaService.topicName)
+      .option(startingOption, partitionsAndOffsets) //this only applies when a new query is started and that resuming will always pick up from where the query left off
+      .load()
       .withColumn(KafkaService.radioStructureName, // nested structure with our json
         from_json($"value".cast(StringType), KafkaService.schemaOutput)
       ) //From binary to JSON object

--- a/src/main/scala/kafka/KafkaSource.scala
+++ b/src/main/scala/kafka/KafkaSource.scala
@@ -33,12 +33,13 @@ object KafkaSource {
     *
     * startingOffsets should use a JSON coming from the lastest offsets saved in our DB (Cassandra here)
     */
-  def read(startingOption: String = "startingOffsets", partitionsAndOffsets: String = "earliest") = {
+    def read(startingOption: String = "startingOffsets", partitionsAndOffsets: String = "earliest") = {
     spark
       .readStream
       .format("kafka")
       .option("kafka.bootstrap.servers", "localhost:9092")
       .option("subscribe", KafkaService.topicName)
+      .option("failOnDataLoss", false) // when starting a fresh kafka (default location is temporary (/tmp) and cassandra is not (var/lib)), we have saved different offsets in Cassandra than real offsets in kafka (that contains nothing)
       .option(startingOption, partitionsAndOffsets) //this only applies when a new query is started and that resuming will always pick up from where the query left off
       .load()
       .withColumn(KafkaService.radioStructureName, // nested structure with our json

--- a/src/main/scala/kafka/KafkaSource.scala
+++ b/src/main/scala/kafka/KafkaSource.scala
@@ -39,6 +39,8 @@ object KafkaSource {
       .format("kafka")
       .option("kafka.bootstrap.servers", "localhost:9092")
       .option("subscribe", KafkaService.topicName)
+      .option("enable.auto.commit", false)
+      .option("group.id", "Structured-Streaming-Examples")
       .option("failOnDataLoss", false) // when starting a fresh kafka (default location is temporary (/tmp) and cassandra is not (var/lib)), we have saved different offsets in Cassandra than real offsets in kafka (that contains nothing)
       .option(startingOption, partitionsAndOffsets) //this only applies when a new query is started and that resuming will always pick up from where the query left off
       .load()


### PR DESCRIPTION
When checkpointing is not available, like in an application upgrade case, we need to save the last offsets per partition in the same transaction of our data linked to these offsets.